### PR TITLE
Peng

### DIFF
--- a/src/ccount/core.py
+++ b/src/ccount/core.py
@@ -47,7 +47,7 @@ class CorrelatedModel:
 
     """
 
-    def __init__(self, m, n, l, d, Y, X, g, f):
+    def __init__(self, m, n, l, d, Y, X, g, f, group_id=None):
         """Correlated Model initialization method.
 
         Parameters
@@ -68,15 +68,23 @@ class CorrelatedModel:
         g : :obj: `list` of :obj: `function`
             List of link functions for each parameter.
         f : function
-            Log likelihood function, better be `numpy.ufunc`.
-
+            Negative log likelihood function, better be `numpy.ufunc`.
+        group_id: :obj: `numpy.ndarray`, optional
+            Optional integer group id, gives the way of grouping the random
+            effects. When it is not `None`, it should have length `m`.
         """
         # dimension
         self.m = m
         self.n = n
         self.l = l
         self.d = d
-        
+
+        # grouping of the random effects
+        if group_id is None:
+            self.group_id = np.arange(self.m)
+        else:
+            self.group_id = group_id
+
         # data and covariates
         self.Y = Y
         self.X = X
@@ -88,12 +96,24 @@ class CorrelatedModel:
         # check input
         self.check()
 
+        # group the data with group_id
+        sort_id = np.argsort(self.group_id)
+        self.group_id = self.group_id[sort_id]
+        self.Y = self.Y[sort_id]
+        for k in range(self.l):
+            for j in range(self.n):
+                self.X[k][j] = self.X[k][j][sort_id]
+
+        self.unique_group_id, self.group_sizes = np.unique(self.group_id,
+                                                           return_counts=True)
+        self.num_groups = self.unique_group_id.size
+
         # fixed effects
         self.beta = [[np.zeros(self.d[k, j])
                       for j in range(self.n)] for k in range(self.l)]
 
         # random effects and its covariance matrix
-        self.U = np.zeros((self.l, self.m, self.n))
+        self.U = np.zeros((self.l, self.num_groups, self.n))
         self.D = np.array([np.identity(self.n) for k in range(self.l)])
 
         # place holder for parameter
@@ -110,7 +130,9 @@ class CorrelatedModel:
         assert isinstance(self.n, int)
         assert isinstance(self.l, int)
         assert isinstance(self.d, np.ndarray)
+        assert isinstance(self.group_id, np.ndarray)
         assert self.d.dtype == int
+        assert self.group_id.dtype == int
 
         assert isinstance(self.Y, np.ndarray)
         assert self.Y.dtype == np.number
@@ -144,6 +166,7 @@ class CorrelatedModel:
                    for j in range(self.n))
 
         assert len(self.g) == self.l
+        assert self.group_id.shape == (self.m,)
         LOG.info("...passed.")
 
     def compute_P(self, beta=None, U=None):

--- a/src/ccount/core.py
+++ b/src/ccount/core.py
@@ -194,6 +194,7 @@ class CorrelatedModel:
                       for k in range(self.l)
                       for j in range(self.n)])
         P = P.reshape((self.l, self.n, self.m)).transpose(0, 2, 1)
+        U = np.repeat(U, self.group_sizes, axis=1)
         P = P + U
         for k in range(self.l):
             P[k] = self.g[k](P[k])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,10 +21,13 @@ X = [[np.random.randn(m, d[k, j])
       for j in range(n)] for k in range(l)]
 
 
-def test_correlated_model():
+@pytest.mark.parametrize("group_id",
+                         [None, np.array([1, 1, 2, 2, 3])])
+def test_correlated_model(group_id):
     cm = core.CorrelatedModel(m, n, l, d, Y, X,
                               [lambda x: x] * l,
-                              lambda y, p: 0.5*(y - p[0])**2)
+                              lambda y, p: 0.5*(y - p[0])**2,
+                              group_id=group_id)
     assert all([np.linalg.norm(cm.beta[k][j]) < 1e-10
                 for k in range(l)
                 for j in range(n)])
@@ -32,6 +35,9 @@ def test_correlated_model():
     assert all([np.linalg.norm(cm.D[k] - np.identity(n)) < 1e-10
                 for k in range(l)])
     assert np.linalg.norm(cm.P) < 1e-10
+
+    if group_id is not None:
+        assert cm.U.shape == (cm.l, 3, cm.n)
 
 
 @pytest.mark.parametrize("beta",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -40,22 +40,29 @@ def test_correlated_model(group_id):
         assert cm.U.shape == (cm.l, 3, cm.n)
 
 
+@pytest.mark.parametrize("group_id",
+                         [None, np.array([1, 1, 2, 2, 3])])
 @pytest.mark.parametrize("beta",
                          [None, [[np.ones(d[k, j])
                                   for j in range(n)] for k in range(l)]])
-@pytest.mark.parametrize("U", [None, np.ones((l, m, n))])
-def test_correlated_model_compute_P(beta, U):
+@pytest.mark.parametrize("U", [None, 1])
+def test_correlated_model_compute_P(group_id, beta, U):
     cm = core.CorrelatedModel(m, n, l, d, Y, X,
                               [lambda x: x] * l,
-                              lambda y, p: 0.5 * (y - p[0]) ** 2)
+                              lambda y, p: 0.5 * (y - p[0]) ** 2,
+                              group_id=group_id)
+    if U is not None:
+        U = np.ones((cm.m, cm.num_groups, cm.n))
     P = cm.compute_P(beta=beta, U=U)
     if beta is None:
         beta = cm.beta
     if U is None:
         U = cm.U
     true_P = np.array([cm.X[k][j].dot(beta[k][j])
-                  for k in range(l)
-                  for j in range(n)])
+                      for k in range(l)
+                      for j in range(n)])
+    if group_id is not None:
+        U = np.repeat(U, cm.group_sizes, axis=1)
     true_P = true_P.reshape((l, n, m)).transpose(0, 2, 1) + U
 
     assert np.linalg.norm(P - true_P) < 1e-10
@@ -89,17 +96,22 @@ def test_correlated_model_update_params(beta, U, D, P):
     assert np.linalg.norm(P - cm.P) < 1e-10
 
 
+@pytest.mark.parametrize("group_id",
+                         [None, np.array([1, 1, 2, 2, 3])])
 @pytest.mark.parametrize("beta",
                          [None, [[np.ones(d[k, j])
                                   for j in range(n)] for k in range(l)]])
-@pytest.mark.parametrize("U", [None, np.zeros((l, m, n))])
+@pytest.mark.parametrize("U", [None, 0])
 @pytest.mark.parametrize("D", [None,
-                               np.array([np.identity(n) for i in range(l)])])
-def test_correlated_model_neg_log_likelihood(beta, U, D):
+                               np.array([np.identity(n)]*l)])
+def test_correlated_model_neg_log_likelihood(group_id, beta, U, D):
     cm = core.CorrelatedModel(m, n, l, d, Y, X,
                               [lambda x: x] * l,
-                              lambda y, p: 0.5*(y - p[0])**2)
+                              lambda y, p: 0.5*(y - p[0])**2,
+                              group_id=group_id)
 
+    if U is not None:
+        U = np.zeros((cm.m, cm.num_groups, cm.n))
     cm.update_params(beta=beta, U=U, D=D)
     assert np.abs(cm.neg_log_likelihood() -
                   0.5*np.mean(np.sum((cm.Y - cm.P[0])**2, axis=1)) -

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -23,9 +23,11 @@ def cm():
     Y = np.random.randn(m, n)
     X = [[np.random.randn(m, d[k, j])
           for j in range(n)] for k in range(l)]
+    group_id = None
     cm = core.CorrelatedModel(m, n, l, d, Y, X,
                               [lambda x: x] * l,
-                              lambda y, p: 0.5*(y - p[0])**2)
+                              lambda y, p: 0.5*(y - p[0])**2,
+                              group_id=group_id)
     return cm
 
 
@@ -49,10 +51,11 @@ def test_optimization_gradient_beta(cm, beta):
     if beta is None:
         beta = cm.beta
     vec = utils.beta_to_vec(beta)
+    full_U = np.repeat(cm.U, cm.group_sizes, axis=1)
 
     assert np.linalg.norm(opt.gradient_beta(vec) -
                           cm.X[0][0].T.dot(
-                              cm.X[0][0].dot(beta[0][0]) + cm.U[0].T[0] -
+                              cm.X[0][0].dot(beta[0][0]) + full_U[0].T[0] -
                               cm.Y.T[0])/cm.m) < 1e-8
 
 
@@ -61,7 +64,8 @@ def test_optimization_objective_U(cm, U):
     opt = cm.opt_interface
     if U is None:
         U = cm.U
-    assert np.abs(opt.objective_U(U.flatten()) - cm.neg_log_likelihood(U=U)) < 1e-10
+    assert np.abs(opt.objective_U(U.flatten()) -
+                  cm.neg_log_likelihood(U=U)) < 1e-10
 
 
 @pytest.mark.parametrize("U", [None, np.ones((l, m, n))])
@@ -69,14 +73,23 @@ def test_optimization_gradient_U(cm, U):
     opt = cm.opt_interface
     if U is None:
         U = cm.U
-    assert np.linalg.norm(opt.gradient_U(U.flatten()) -
-                          (cm.X[0][0].dot(cm.beta[0][0]) + U.flatten() -
-                          cm.Y.T[0])/cm.m - U.flatten()/cm.m) < 1e-10
+    full_U = np.repeat(U, cm.group_sizes, axis=1)
+
+    my_grad = opt.gradient_U(U.flatten()).reshape(cm.U.shape)
+    tr_grad = (cm.X[0][0].dot(cm.beta[0][0]) + full_U.flatten() -
+               cm.Y.T[0])/cm.m
+    tr_grad = tr_grad.reshape(full_U.shape)
+    tr_grad = np.add.reduceat(tr_grad,
+                              np.cumsum([0] + list(cm.group_sizes))[:-1],
+                              axis=1)
+    tr_grad += U/cm.num_groups
+    assert np.linalg.norm(my_grad - tr_grad) < 1e-10
 
 
 def test_optimization_optimize_beta(cm):
     mat = cm.X[0][0]
-    vec = cm.Y.T[0] - cm.U.flatten()
+    full_U = np.repeat(cm.U, cm.group_sizes, axis=1)
+    vec = cm.Y.T[0] - full_U.flatten()
     true_beta = np.linalg.solve(mat.T.dot(mat), mat.T.dot(vec))
     cm.opt_interface.optimize_beta()
     assert np.linalg.norm(true_beta - utils.beta_to_vec(cm.beta)) < 1e-5
@@ -85,7 +98,8 @@ def test_optimization_optimize_beta(cm):
 def test_optimization_optimize_U(cm):
     true_U = 0.5*(cm.Y.T[0] - cm.X[0][0].dot(cm.beta[0][0]))
     cm.opt_interface.optimize_U()
-    assert np.linalg.norm(true_U - cm.U.flatten()) < 1e-5
+    full_U = np.repeat(cm.U, cm.group_sizes, axis=1)
+    assert np.linalg.norm(true_U - full_U.flatten()) < 1e-5
 
 
 def test_optimization_compute_D(cm):


### PR DESCRIPTION
Add optional variable `group_id` to the class `core.CorrelatedModel`.
Automatically organized the data according to `group_id`, and shrink the second dimension (individual) of the random effects from `m` to `num_groups`.
When `group_id` is None (default), it assumes every individual is a single group, which is consistent before the change.