### PR TITLE
Include an offset by parameter

### DIFF
--- a/src/ccount/core.py
+++ b/src/ccount/core.py
@@ -91,7 +91,7 @@ class CorrelatedModel:
 
         # offset for each parameter
         if offset is None:
-            self.offset = [np.zeros(self.m)] * 3
+            self.offset = [np.zeros(self.m)] * self.l
         else:
             self.offset = [off if off is not None else np.zeros(self.m) for off in offset]
 
@@ -146,7 +146,7 @@ class CorrelatedModel:
         assert self.group_id.dtype == int
         assert isinstance(self.offset, list)
         for offset_k in self.offset:
-            assert isinstance(offset_k, np.array)
+            assert isinstance(offset_k, np.ndarray)
 
         assert isinstance(self.Y, np.ndarray)
         assert self.Y.dtype == np.number
@@ -238,11 +238,12 @@ class CorrelatedModel:
         P = np.array([X[k][j].dot(beta[k][j])
                       for k in range(self.l)
                       for j in range(self.n)])
+        for k in range(self.l):
+            P[k] = P[k] + offset[k]
         P = P.reshape((self.l, self.n, m)).transpose(0, 2, 1)
         U = np.repeat(U, group_sizes, axis=1)
         P = P + U
         for k in range(self.l):
-            P[k] = P[k] + offset[k]
             P[k] = self.g[k](P[k])
         return P
 

--- a/src/ccount/models.py
+++ b/src/ccount/models.py
@@ -12,12 +12,12 @@ class HurdlePoisson(CorrelatedModel):
     for the proportion of zeros, and a zero-truncated
     Poisson for the
     """
-    def __init__(self, m, d, Y, X, group_id=None):
+    def __init__(self, m, d, Y, X, group_id=None, offset=None):
         LOG.info("Initializing a Hurdle Poisson Model.")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
-            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id,
+            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
             l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
             f=NegLogLikelihoods.hurdle_poisson
         )
@@ -42,12 +42,12 @@ class ZeroInflatedPoisson(CorrelatedModel):
     >>> zp = ZeroInflatedPoisson(m=ps.m, d=D, Y=Y, X=X)
     >>> zp.optimize_params()
     """
-    def __init__(self, m, d, Y, X, group_id=None):
+    def __init__(self, m, d, Y, X, group_id=None, offset=None):
         LOG.info("Initializing a Zero-Inflated Poisson Model")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
-            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id,
+            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
             l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
             f=NegLogLikelihoods.zi_poisson
         )
@@ -63,12 +63,12 @@ class NegativeBinomial(CorrelatedModel):
     """
     A Negative Binomial Model.
     """
-    def __init__(self, m, d, Y, X, group_id=None):
+    def __init__(self, m, d, Y, X, group_id=None, offset=None):
         LOG.info("Initializing a negative binomial model.")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
-            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id,
+            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
             l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
             f=NegLogLikelihoods.nbinom
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,18 +42,21 @@ def test_correlated_model(group_id):
 
 @pytest.mark.parametrize("group_id",
                          [None, np.array([1, 1, 2, 2, 3])])
+@pytest.mark.parametrize("offset",
+                          [np.zeros(5)])
 @pytest.mark.parametrize("beta",
                          [None, [[np.ones(d[k, j])
                                   for j in range(n)] for k in range(l)]])
 @pytest.mark.parametrize("U", [None, 1])
-def test_correlated_model_compute_P(group_id, beta, U):
+def test_correlated_model_compute_P(group_id, beta, U, offset):
     cm = core.CorrelatedModel(m, n, l, d, Y, X,
                               [lambda x: x] * l,
                               lambda y, p: 0.5 * (y - p[0]) ** 2,
                               group_id=group_id)
     if U is not None:
         U = np.ones((cm.m, cm.num_groups, cm.n))
-    P = cm.compute_P(beta=beta, U=U, X=cm.X, m=cm.m, group_sizes=cm.group_sizes)
+    P = cm.compute_P(beta=beta, U=U, X=cm.X, m=cm.m,
+                     group_sizes=cm.group_sizes, offset=offset)
     if beta is None:
         beta = cm.beta
     if U is None:


### PR DESCRIPTION
Include an optional offset for each parameter, e.g. the population size from which incidence and mortality were drawn from. Goes into directly computing P, before the `g` link function transformation.