### PR TITLE
Likelihood weights

### DIFF
--- a/src/ccount/models.py
+++ b/src/ccount/models.py
@@ -42,12 +42,13 @@ class ZeroInflatedPoisson(CorrelatedModel):
     >>> zp = ZeroInflatedPoisson(m=ps.m, d=D, Y=Y, X=X)
     >>> zp.optimize_params()
     """
-    def __init__(self, m, d, Y, X, group_id=None, offset=None):
+    def __init__(self, m, d, Y, X, group_id=None, offset=None, weights=None):
         LOG.info("Initializing a Zero-Inflated Poisson Model")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
-            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
+            m=m, n=2, d=d, Y=Y.astype(np.number), X=X,
+            group_id=group_id, offset=offset, weights=weights,
             l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
             f=NegLogLikelihoods.zi_poisson
         )


### PR DESCRIPTION
Added a weight vector of shape `(m, n)` (number of individuals, number of outcomes) to multiply the negative log likelihood by. The values of the weights must be determined in the model-specific classes, so that they are implemented in a standard way in `ccount.core.CorrelatedModel`.