### PR TITLE
Added option to scale X and add an intercept

### DIFF
--- a/src/ccount/models.py
+++ b/src/ccount/models.py
@@ -46,13 +46,13 @@ class ZeroInflatedPoisson(CorrelatedModel):
     >>> zp = ZeroInflatedPoisson(m=ps.m, d=D, Y=Y, X=X)
     >>> zp.optimize_params()
     """
-    def __init__(self, m, d, Y, X, group_id=None, offset=None, weights=None):
+    def __init__(self, m, d, Y, X, group_id=None, offset=None, weights=None, normalize_X=False):
         LOG.info("Initializing a Zero-Inflated Poisson Model")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
             m=m, n=2, d=d, Y=Y.astype(np.number), X=X,
-            group_id=group_id, offset=offset, weights=weights,
+            group_id=group_id, offset=offset, weights=weights, normalize_X=normalize_X,
             l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
             f=NegLogLikelihoods.zi_poisson
         )


### PR DESCRIPTION
**Intercept**
Added the option to add an intercept to the core model so that we don't have to pass it in every time. If you don't want to add covariates for a parameter / outcome, you can pass add_intercept = True and it will add it for every parameter / outcome, but then put None as your X for that parameter and outcome, e.g.:

`X = [[None, None], [covariates, covariates]], ..., add_intercept = True`

to put covariates on just the second parameter. Passing the above X and add_intercept = False will give a `RuntimeError`.

**Scaling**
Option to normalize X with `normalize_X = True` (subtract mean, divide by standard deviation). If X is normalized, then the interpretation of the intercept is the mean value for observations with average covariate values. The betas are then the change in the link outcome for every standard deviation change in X. We back-transform the betas in the `CorrelatedModel.summarize()` method to make interpretation easier.