### PR TITLE
Smooth ReLU link function for Poisson

### DIFF
--- a/src/ccount/core.py
+++ b/src/ccount/core.py
@@ -253,13 +253,13 @@ class CorrelatedModel:
         P = np.array([X[k][j].dot(beta[k][j])
                       for k in range(self.l)
                       for j in range(self.n)])
-        for k in range(self.l):
-            P[k] = P[k] + offset[k]
         P = P.reshape((self.l, self.n, m)).transpose(0, 2, 1)
         U = np.repeat(U, group_sizes, axis=1)
         P = P + U
         for k in range(self.l):
             P[k] = self.g[k](P[k])
+        for k in range(self.l):
+            P[k] = P[k] * offset[k]
         return P
 
     def update_params(self, beta=None, U=None, D=None, P=None):

--- a/src/ccount/core.py
+++ b/src/ccount/core.py
@@ -97,9 +97,9 @@ class CorrelatedModel:
 
         # offset for each parameter
         if offset is None:
-            self.offset = [np.zeros(self.m)] * self.l
+            self.offset = [np.ones((self.m, 1))] * self.l
         else:
-            self.offset = [off if off is not None else np.zeros(self.m) for off in offset]
+            self.offset = [off if off is not None else np.ones(self.m) for off in offset]
 
         # weights to put on the negative log likelihood
         if weights is None:
@@ -202,7 +202,7 @@ class CorrelatedModel:
         assert self.group_id.shape == (self.m,)
         assert len(self.offset) == self.l
         for offset_k in self.offset:
-            assert offset_k.shape == (self.m,)
+            assert offset_k.shape == (self.m, 1)
         assert self.W.shape == (self.m, self.n)
 
         LOG.info("...passed.")

--- a/src/ccount/link_functions.py
+++ b/src/ccount/link_functions.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+
+def expit(x):
+    return np.exp(x) / (1 + np.exp(x))
+
+
+def smooth_ReLU(x, x_limit=50):
+    above_limit = x > x_limit
+    return above_limit * x + ~above_limit * np.log(1 + np.exp(x))

--- a/src/ccount/models.py
+++ b/src/ccount/models.py
@@ -1,7 +1,9 @@
 import numpy as np
+import logging
+
 from ccount.core import CorrelatedModel
 from ccount.likelihoods import NegLogLikelihoods
-import logging
+from ccount.utils import smooth_ReLU
 
 LOG = logging.getLogger(__name__)
 
@@ -12,12 +14,12 @@ class HurdlePoisson(CorrelatedModel):
     for the proportion of zeros, and a zero-truncated
     Poisson for the
     """
-    def __init__(self, m, d, Y, X, group_id=None, offset=None):
+    def __init__(self, m, n, d, Y, X, group_id=None, offset=None):
         LOG.info("Initializing a Hurdle Poisson Model.")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
-            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
+            m=m, n=n, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
             l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
             f=NegLogLikelihoods.hurdle_poisson
         )
@@ -46,12 +48,12 @@ class ZeroInflatedPoisson(CorrelatedModel):
     >>> zp = ZeroInflatedPoisson(m=ps.m, d=D, Y=Y, X=X)
     >>> zp.optimize_params()
     """
-    def __init__(self, m, d, Y, X, group_id=None, offset=None, weights=None):
+    def __init__(self, m, n, d, Y, X, group_id=None, offset=None, weights=None):
         LOG.info("Initializing a Zero-Inflated Poisson Model")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
-            m=m, n=2, d=d, Y=Y.astype(np.number), X=X,
+            m=m, n=n, d=d, Y=Y.astype(np.number), X=X,
             group_id=group_id, offset=offset, weights=weights,
             l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
             f=NegLogLikelihoods.zi_poisson
@@ -68,16 +70,37 @@ class ZeroInflatedPoisson(CorrelatedModel):
         return (1 - p) * theta
 
 
+class ZeroInflatedPoissonSmoothReLU(CorrelatedModel):
+    """
+    A Zero-Inflated Poisson likelihood with a Smooth ReLU link function
+    rather than a log link for the Poisson mean.
+    """
+    def __init__(self, m, n, d, Y, X, group_id=None, offset=None):
+        LOG.info("Initializing a Zero-Inflated Poisson SmoothReLU Model")
+        assert len(d) == 2
+        assert len(X) == 2
+        super().__init__(
+            m=m, n=n, d=d, Y=Y.astype(np.number), X=X,
+            group_id=group_id, offset=offset,
+            l=2, g=[np.exp, smooth_ReLU],
+            f=NegLogLikelihoods.zi_poisson
+        )
+        self.model_type = "Zero-Inflated Poisson Smooth ReLU"
+        self.parameters = [
+            "Mean of Poisson", "Over-Dispersion Parameter Variance"
+        ]
+
+
 class NegativeBinomial(CorrelatedModel):
     """
     A Negative Binomial Model.
     """
-    def __init__(self, m, d, Y, X, group_id=None, offset=None):
+    def __init__(self, m, n, d, Y, X, group_id=None, offset=None):
         LOG.info("Initializing a negative binomial model.")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
-            m=m, n=2, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
+            m=m, n=n, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
             l=2, g=[np.exp, np.exp],
             f=NegLogLikelihoods.nbinom
         )

--- a/src/ccount/models.py
+++ b/src/ccount/models.py
@@ -3,7 +3,7 @@ import logging
 
 from ccount.core import CorrelatedModel
 from ccount.likelihoods import NegLogLikelihoods
-from ccount.utils import smooth_ReLU
+from ccount.link_functions import smooth_ReLU, expit
 
 LOG = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class HurdlePoisson(CorrelatedModel):
         assert len(X) == 2
         super().__init__(
             m=m, n=n, d=d, Y=Y.astype(np.number), X=X, group_id=group_id, offset=offset,
-            l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
+            l=2, g=[expit, np.exp],
             f=NegLogLikelihoods.hurdle_poisson
         )
         self.model_type = "Hurdle Poisson"
@@ -55,7 +55,7 @@ class ZeroInflatedPoisson(CorrelatedModel):
         super().__init__(
             m=m, n=n, d=d, Y=Y.astype(np.number), X=X,
             group_id=group_id, offset=offset, weights=weights,
-            l=2, g=[lambda x: np.exp(x) / (1 + np.exp(x)), np.exp],
+            l=2, g=[expit, np.exp],
             f=NegLogLikelihoods.zi_poisson
         )
         self.model_type = "Zero-Inflated Poisson"
@@ -82,12 +82,12 @@ class ZeroInflatedPoissonSmoothReLU(CorrelatedModel):
         super().__init__(
             m=m, n=n, d=d, Y=Y.astype(np.number), X=X,
             group_id=group_id, offset=offset,
-            l=2, g=[np.exp, smooth_ReLU],
+            l=2, g=[expit, smooth_ReLU],
             f=NegLogLikelihoods.zi_poisson
         )
         self.model_type = "Zero-Inflated Poisson Smooth ReLU"
         self.parameters = [
-            "Mean of Poisson", "Over-Dispersion Parameter Variance"
+            "Probability of Structural Zero", "Mean of Poisson"
         ]
 
 

--- a/src/ccount/models.py
+++ b/src/ccount/models.py
@@ -75,13 +75,13 @@ class ZeroInflatedPoissonSmoothReLU(CorrelatedModel):
     A Zero-Inflated Poisson likelihood with a Smooth ReLU link function
     rather than a log link for the Poisson mean.
     """
-    def __init__(self, m, n, d, Y, X, group_id=None, offset=None):
+    def __init__(self, m, n, d, Y, X, group_id=None, offset=None, weights=None):
         LOG.info("Initializing a Zero-Inflated Poisson SmoothReLU Model")
         assert len(d) == 2
         assert len(X) == 2
         super().__init__(
             m=m, n=n, d=d, Y=Y.astype(np.number), X=X,
-            group_id=group_id, offset=offset,
+            group_id=group_id, offset=offset, weights=weights,
             l=2, g=[expit, smooth_ReLU],
             f=NegLogLikelihoods.zi_poisson
         )

--- a/src/ccount/utils.py
+++ b/src/ccount/utils.py
@@ -8,11 +8,6 @@
 import numpy as np
 
 
-def smooth_ReLU(x, x_limit=50):
-    above_limit = x > x_limit
-    return above_limit * x + ~above_limit * np.log(1 + np.exp(x))
-
-
 def vec_to_beta(vec, d):
     """Convert vector into correlated model beta structure.
 

--- a/src/ccount/utils.py
+++ b/src/ccount/utils.py
@@ -8,6 +8,11 @@
 import numpy as np
 
 
+def smooth_ReLU(x, x_limit=50):
+    above_limit = x > x_limit
+    return above_limit * x + ~above_limit * np.log(1 + np.exp(x))
+
+
 def vec_to_beta(vec, d):
     """Convert vector into correlated model beta structure.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,7 +43,7 @@ def test_correlated_model(group_id):
 @pytest.mark.parametrize("group_id",
                          [None, np.array([1, 1, 2, 2, 3])])
 @pytest.mark.parametrize("offset",
-                          [np.zeros(5)])
+                          [np.ones((5, 1))])
 @pytest.mark.parametrize("beta",
                          [None, [[np.ones(d[k, j])
                                   for j in range(n)] for k in range(l)]])


### PR DESCRIPTION
**Smooth ReLU Transformation**
Added a new model type that uses the inverse of the smooth ReLU (aka softplus) link function for the zero-inflated Poisson likelihood. The assumption is that
```
log(exp(E[Y|X]) - 1) = Xβ
```
and so the function used to transform `Xβ` is `log(1 + exp(x))`.

_Note: Will have to figure out a different transformation for the offset, or to use weights on the likelihood directly instead._

**Offset Multiplication**
Previously, we were adding whatever g(offset) was passed in to the mean before transformation, i.e. `E[Y|X] = inverse_link(Xβ + g(offset)). This means that it was up to the user to decide what transformation would result in
```
E[Y|X] / offset = inverse_link(Xβ)
```
For the Poisson, this transformation is log because `E[Y|X] = exp(Xβ + log(offset)) = exp(Xβ) offset`. It is not straightforward (if not impossible?) to find what this function `g(offset)` would be for the smooth ReLU such that `log(1 + exp(x + g(offset))) = log(1 + exp(x)) * offset`.

So, changed the calculation in `CorrelatedModel.compute_P()` so that instead of adding g(offset) and making the user specify what this transformation is, we always multiply `P` by the offset directly, after transformation. This way we always have `E[Y|X] / offset = inverse_link(Xβ)` and so it is always a valid offset.

**Link Function Module**
Added a new module for link functions in case we try other new ones in the future.